### PR TITLE
fix: fixed search while not a first page

### DIFF
--- a/projects/ngx-easy-table/src/lib/components/base/base.component.html
+++ b/projects/ngx-easy-table/src/lib/components/base/base.component.html
@@ -528,6 +528,7 @@
   </table>
   <pagination
     [attr.id]="'pagination' + id"
+    [rouwCount]="filterCount"
     [id]="id"
     #paginationComponent
     [config]="config"

--- a/projects/ngx-easy-table/src/lib/components/pagination/pagination.component.ts
+++ b/projects/ngx-easy-table/src/lib/components/pagination/pagination.component.ts
@@ -23,6 +23,8 @@ export interface PaginationRange {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PaginationComponent implements OnChanges {
+  #rowCount: number;
+  private currentPage = 1;
   @ViewChild('paginationDirective', { static: true })
   paginationDirective: PaginationControlsDirective;
   @ViewChild('paginationRange') paginationRange;
@@ -40,6 +42,23 @@ export class PaginationComponent implements OnChanges {
   public nextLabel = '';
   public directionLinks = true;
 
+  get rouwCount(): number {
+    return this.#rowCount;
+  }
+
+  @Input()
+  set rouwCount(value: number) {
+    this.#rowCount = value;
+
+    if (this.#rowCount < (this.currentPage - 1) * this.selectedLimit) {
+      this.currentPage = 1;
+      this.updateRange.emit({
+        page: this.currentPage,
+        limit: this.selectedLimit,
+      });
+    }
+  }
+  
   @HostListener('document:click', ['$event.target'])
   public onClick(targetElement: any): void {
     if (this.paginationRange && !this.paginationRange.nativeElement.contains(targetElement)) {
@@ -55,6 +74,7 @@ export class PaginationComponent implements OnChanges {
   }
 
   onPageChange(page: number): void {
+    this.currentPage = page;
     this.updateRange.emit({
       page,
       limit: this.selectedLimit,
@@ -66,8 +86,9 @@ export class PaginationComponent implements OnChanges {
       this.showRange = !this.showRange;
     }
     this.selectedLimit = limit;
+    this.currentPage = 1;
     this.updateRange.emit({
-      page: 1,
+      page: this.currentPage,
       limit,
     });
   }


### PR DESCRIPTION
fix for issue https://github.com/ssuperczynski/ngx-easy-table/issues/333

- The fix is a reset of the selected page when paging is active while searching
- Added test with search action from page 2
- Fixed a typing for event